### PR TITLE
Run perl script with UID to match EUID

### DIFF
--- a/gpgit
+++ b/gpgit
@@ -22,6 +22,7 @@
 
 use strict;
 use warnings;
+use English;
 use Mail::GnuPG;
 use MIME::Parser;
 


### PR DESCRIPTION
This helps avoid an error where GnuPG won't run if the uid does
not match the euid returning error like
"Error: secmem usage: 0/0 bytes in 0/0 blocks"
