### PR TITLE
Remove incorrect -p flag from mktemp

### DIFF
--- a/encmaildir.sh
+++ b/encmaildir.sh
@@ -78,6 +78,7 @@ while IFS= read -d $'\0' -r mail; do
 	echo "    --gpgit--> '$tempmsg'"
 	if ! "$gpgit" "$2" < "$mail" >> "$tempmsg"; then
 		echo "    Error:     Gpgit failed. Skipping ..." >&2
+		rm "$tempmsg"
 		continue
 	fi
 

--- a/encmaildir.sh
+++ b/encmaildir.sh
@@ -5,6 +5,9 @@
 # Aug 4, 2012
 #
 # Change log:
+#     Oct 10, 2015 (Michael F. Herbst)
+#               - Remove obsolete -p from mktemp
+#
 #     Aug 4, 2012 (Etienne Perot)
 #               - Remove third argument
 #               - Changed default encryption mode to PGP/MIME (gpgit default)
@@ -60,8 +63,8 @@ find "$1" -type f -name '*.tmp_you_can_delete_me.*' -delete
 echo "Calling \`find \"$1\" -type f -regex '.*/\(cur\|new\)/.*' $3\`"
 while IFS= read -d $'\0' -r mail; do
 	# Create file unreadable except by ourselves
-	tempmsg="$(mktemp -p "$mail.tmp_you_can_delete_me.XXXXXXXXXXX")"
-	chmod 600 "$tempmsg"
+	tempmsg="$(mktemp "$mail.tmp_you_can_delete_me.XXXXXXXXXXX")"
+	chmod 600 "$tempmsg" # mktemp should have created the file as 600 already
 
 	# This is where the magic happens
 	"$gpgit" "$2" < "$mail" >> "$tempmsg"


### PR DESCRIPTION
See manpage of mktemp.
The -p flag caused mktemp to generate the temporary file inside a
directory called '$mail.tmp_you_can_delete_me.XXXXXXXXXXX' which of
cause does not exist. Thence the script failed.
